### PR TITLE
Fix path delimiters in Windows

### DIFF
--- a/pathSetup.js
+++ b/pathSetup.js
@@ -11,9 +11,9 @@ module.exports = function(filePath) {
   root = path.dirname(p);
   orig = process.env.NODE_PATH ? process.env.NODE_PATH : '';
   if (filePath) {
-    process.env.NODE_PATH = path.join(root, '../libs') + ':' + orig;
+    process.env.NODE_PATH = path.join(root, '../libs') + path.delimiter + orig;
   } else {
-    process.env.NODE_PATH = root + ':' + orig;
+    process.env.NODE_PATH = root + path.delimiter + orig;
   }
   return require('module')._initPaths();
 };


### PR DESCRIPTION
Use `path.delimiter` to get the system specific path delimiter.

http://nodejs.org/api/modules.html#modules_loading_from_the_global_folders
