### PR TITLE
New param: mk requires rel to a project subfolder

### DIFF
--- a/pathSetup.js
+++ b/pathSetup.js
@@ -1,14 +1,32 @@
 var path = require('path');
 var fs = require('fs');
 
+/**
+ * Make require calls relative to your project root, or to a specific folder
+ * within your project (e.g. a "build" folder).
+ *
+ * @example e.g. require('rootpath')()
+ * @example e.g. require('rootpath')({ isRelative: true, path: "build"})
+ * @param  {String|Object} filePath - a given string becomes new absolute path
+ *           require calls will be made relative to. If object with property
+ *           filePath.isRelative === true, path becomes filePath.path.
+ */
 module.exports = function(filePath) {
-  var orig, p, root, stat;
+  var orig, p, root, stat, newPath;
+  if (typeof filePath === 'object'){
+    if (!!filePath.isRelative){
+        newPath = filePath.path;
+        filePath = null;
+    } else {
+        filePath = filePath.path;
+    }
+  }
   p = filePath || path.join(__filename, '../../');
   stat = fs.lstatSync(p);
   if (stat.isSymbolicLink()) {
     p = fs.readlinkSync(p);
   }
-  root = path.dirname(p);
+  root = (!!newPath) ? path.join(path.dirname(p), "/", newPath, "/") : path.dirname(p);
   orig = process.env.NODE_PATH ? process.env.NODE_PATH : '';
   if (filePath) {
     process.env.NODE_PATH = path.join(root, '../libs') + path.delimiter + orig;


### PR DESCRIPTION
Set up filePath parameter to let users specify a subfolder (relative to project root) within the project as the new project root. Kept backwards compatibility with previous use of filePath as an absolute path that could be set as the project root.

If filePath is 1) an object, 2) contains an 'isRelative' property which is equal to true; and 3) contains a 'path' property that is a string - then the root path will become [actual project root]/filePath.path. E.g.
require('rootpath')({ isRelative: true, path: "build"});
...
results in the root (for require calls) being set to [project root]/build.

I also documented the function :)
