### PR TITLE
Option to include PWD in node paths

### DIFF
--- a/pathSetup.js
+++ b/pathSetup.js
@@ -1,7 +1,7 @@
 var path = require('path');
 var fs = require('fs');
 
-module.exports = function(filePath) {
+module.exports = function(filePath, includePWD) {
   var orig, p, root, stat;
   p = filePath || path.join(__filename, '../../');
   stat = fs.lstatSync(p);
@@ -15,6 +15,8 @@ module.exports = function(filePath) {
   } else {
     process.env.NODE_PATH = root + path.delimiter + orig;
   }
+  if (includePWD) {
+    process.env.NODE_PATH = process.env.PWD + ":" + process.env.NODE_PATH;
+  }
   return require('module')._initPaths();
 };
-

--- a/pathSetup.js
+++ b/pathSetup.js
@@ -1,7 +1,7 @@
 var path = require('path');
 var fs = require('fs');
 
-module.exports = function(filePath, includePWD) {
+module.exports = function(filePath, dontIncludePWD) {
   var orig, p, root, stat;
   p = filePath || path.join(__filename, '../../');
   stat = fs.lstatSync(p);
@@ -15,7 +15,7 @@ module.exports = function(filePath, includePWD) {
   } else {
     process.env.NODE_PATH = root + path.delimiter + orig;
   }
-  if (includePWD) {
+  if (dontIncludePWD !== true) {
     process.env.NODE_PATH = process.env.PWD + ":" + process.env.NODE_PATH;
   }
   return require('module')._initPaths();


### PR DESCRIPTION
Attempting to use this library with yarn workspaces seems to fail (since the paths resolve to the root yarn package instead of the workspace). Thus it would be nice to pass a flaw to include process.env.cwd in the NODE_PATH